### PR TITLE
relax regex to ignore extra query params

### DIFF
--- a/whatapi.py
+++ b/whatapi.py
@@ -184,7 +184,7 @@ class WhatAPI:
         else:
             media_params = ['&media={0}'.format(media_search_map[m]) for m in media]
 
-        pattern = re.compile(r'reportsv2\.php\?action=report&amp;id=(\d+)".*?torrents\.php\?id=(\d+)"', re.MULTILINE | re.IGNORECASE | re.DOTALL)
+        pattern = re.compile(r'reportsv2\.php\?action=report&amp;id=(\d+)".*?torrents\.php\?id=(\d+).*?"', re.MULTILINE | re.IGNORECASE | re.DOTALL)
         if mode == 'snatched' or mode == 'both' or mode == 'all':
             url = '{0}/torrents.php?type=snatched&userid={1}&format=FLAC'.format(self.endpoint, self.userid)
             for mp in media_params:


### PR DESCRIPTION
modify the regex pattern for matching candidates in order to account for any extra URL query params found after `id`